### PR TITLE
Add configurable p‑value curves; simplify UI; remove β CI tables; robustness fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pathj
 Type: Package
 Title: Path Analysis
-Version: 1.1.3
+Version: 1.1.4
 Author: Marcello Gallucci
 Maintainer: Marcello Gallucci <mcfanda@gmail.com>
 Description: Path analysis based on lavaan, with jamovi output style and functions. Provides access to lavaan

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -113,6 +113,22 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             private$.data_machine<-data_machine
             plot_machine$initPlots()
             private$.plot_machine<-plot_machine 
+
+            ## init p-graphs images per group (separate panels)
+            if (self$options$pgraphs) {
+                images <- self$results$pgraphs$pcurves
+                if (is.something(data_machine$multigroup))  {
+                    for (level in data_machine$multigroup$levels) {
+                        images$addItem(level)
+                        images$get(key = level)$setTitle(paste(data_machine$multigroup$var, "=", level))
+                        images$get(key = level)$setState(list(gkey = level))
+                    }
+                } else {
+                    images$addItem("All")
+                    images$get(key = "All")$setTitle("")
+                    images$get(key = "All")$setState(list(gkey = NULL))
+                }
+            }
             
             
         },
@@ -256,9 +272,298 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
 
             if (note)
                 self$results$pathgroup$notes$setVisible(TRUE)
-
+            
             return(TRUE)
 
+        },
+        .plotPvalues=function(image, ggtheme, theme, ...) {
+            if (self$options$pgraphs==FALSE)
+                return()
+
+            dm <- private$.data_machine
+            lavm <- private$.lav_machine
+            # work with a plain data.frame copy of the source data
+            alldata <- as.data.frame(self$data)
+            mg <- dm$multigroup
+
+            .sizesFor <- function(N) {
+                base <- c(50, 100, 200, 500)
+                ss <- base[base <= N]
+                if (length(ss) == 0) {
+                    ss <- unique(round(c(max(5, floor(N*0.33)), max(6, floor(N*0.66)), N)))
+                    ss <- ss[ss <= N]
+                }
+                unique(sort(ss))
+            }
+
+            ## New: project p-values from standardized effects without resampling
+            {
+                # parse sizes from options (comma/space separated), fallback to defaults
+                .parseSizes <- function(s) {
+                    if (is.null(s) || length(s) == 0) return(c(50,100,200,500))
+                    s <- as.character(s)
+                    parts <- unlist(strsplit(s, "[,;\t\n\r ]+"))
+                    v <- suppressWarnings(as.numeric(parts))
+                    v <- unique(sort(v[is.finite(v) & v >= 2]))
+                    if (length(v) == 0) v <- c(50,100,200,500)
+                    v
+                }
+                sizes <- .parseSizes(try(self$options$pcurve_sizes, silent=TRUE))
+                tab <- lavm$tab_coefficients
+                if (is.something(tab)) {
+                    tab$z <- suppressWarnings(as.numeric(tab$z))
+                    tab <- tab[is.finite(tab$z), , drop=FALSE]
+                    # capture standardized beta for labelling
+                    if ("std.all" %in% names(tab))
+                        tab$beta <- suppressWarnings(as.numeric(tab$std.all))
+                    else
+                        tab$beta <- NA_real_
+                }
+                if (!is.something(tab) || nrow(tab)==0) {
+                    jmvcore::reject("Model has no regression coefficients to plot")
+                    return()
+                }
+                # group sizes
+                nobs <- try(lavaan::lavInspect(lavm$model, "nobs"), silent=TRUE)
+                nmap <- list()
+                if (inherits(nobs, "try-error")) {
+                    nmap[["All"]] <- nrow(as.data.frame(self$data))
+                } else if (is.list(nobs)) {
+                    for (nm in names(nobs)) nmap[[nm]] <- as.numeric(nobs[[nm]])
+                } else if (length(nobs) > 1 && is.something(mg)) {
+                    for (i in seq_along(mg$levels)) nmap[[mg$levels[[i]]]] <- as.numeric(nobs[[i]])
+                } else if (length(nobs) == 1) {
+                    nmap[["All"]] <- as.numeric(nobs)
+                }
+
+                rows <- list()
+                for (i in seq_len(nrow(tab))) {
+                    g <- if ("lgroup" %in% names(tab)) as.character(tab$lgroup[i]) else "All"
+                    Nobs <- suppressWarnings(as.numeric(nmap[[g]]))
+                    # Guard against missing/invalid group sizes causing NA in if() condition
+                    if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
+                    z0 <- as.numeric(tab$z[i])
+                    for (n in sizes) {
+                        zn <- z0 * sqrt(n / Nobs)
+                        p <- 2 * stats::pnorm(-abs(zn))
+                        rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
+                    }
+                }
+                d <- if (length(rows)>0) do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors=FALSE)) else NULL
+                if (is.null(d) || nrow(d)==0) {
+                    jmvcore::reject("Could not compute projected p-values")
+                    return()
+                }
+                d$p <- pmin(pmax(as.numeric(d$p), 0), 1)
+                d$n <- as.numeric(d$n)
+                d <- d[order(d$n), , drop=FALSE]
+                # label with beta per path (same within a group)
+                fmtb <- function(x) ifelse(is.finite(x), sprintf("%.3f", x), "NA")
+                d$lab <- paste0(d$rhs, " \u2192 ", d$lhs, " (\u03B2=", fmtb(as.numeric(d$beta)), ")")
+
+                baseBreaks <- sizes
+                brks <- baseBreaks
+
+                # filter per-image group
+                ttl <- "Mean p-values vs Sample Size"
+                if (is.something(mg) && !is.null(image$state$gkey)) {
+                    d <- d[d$group == image$state$gkey, , drop=FALSE]
+                    ttl <- paste0(image$state$gkey, ": Mean p-values vs Sample Size")
+                }
+                # line style options
+                .lt <- try(as.character(self$options$pcurve_linetype), silent=TRUE)
+                if (!is.character(.lt) || length(.lt) == 0 || ! .lt[1] %in% c("solid","dashed","dotted")) .lt <- "solid"
+                .lw <- try(as.numeric(self$options$pcurve_lwd), silent=TRUE)
+                if (!is.finite(.lw) || .lw <= 0) .lw <- 1.2
+
+                p <- ggplot2::ggplot() +
+                     ggplot2::scale_x_continuous(breaks = brks) +
+                     ggplot2::scale_y_continuous(limits = c(0, 1)) +
+                     ggplot2::geom_hline(ggplot2::aes(yintercept = 0.05, linetype = "p = 0.05"), color = "red", show.legend = TRUE) +
+                     ggplot2::scale_linetype_manual(values = c("p = 0.05" = "dashed"), name = "") +
+                     ggplot2::labs(x = "Sample size (n)", y = "Mean p-value", color = "Predictor", title = ttl) +
+                     ggplot2::theme_minimal(base_size = 12)
+                # palette option
+                .pal <- try(as.character(self$options$pcurve_palette), silent=TRUE)
+                if (is.character(.pal) && length(.pal) > 0 && .pal[1] == "okabeito") {
+                    okabeito <- c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
+                    p <- p + ggplot2::scale_color_manual(values = okabeito)
+                }
+                p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), linetype=.lt, size=.lw) +
+                        ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), size = 2)
+                print(p)
+                return(TRUE)
+            }
+
+            out <- list()
+            reps <- 5
+
+            if (is.something(mg)) {
+                # resolve the grouping column name robustly
+                possibles <- unique(c(mg$var, mg$var64, try(jmvcore::toB64(mg$var), silent=TRUE), try(jmvcore::fromB64(mg$var64), silent=TRUE)))
+                possibles <- as.character(possibles[!is.na(possibles)])
+                gvar <- possibles[possibles %in% names(alldata)][1]
+                if (!is.something(gvar)) {
+                    # fallback to no-group plot
+                    mg <- NULL
+                }
+            }
+
+            if (is.something(mg)) {
+                # robustly determine group levels from the actual data
+                gvec <- alldata[[gvar]]
+                gfac <- as.factor(gvec)
+                tab <- table(gfac)
+                levs <- names(tab)             # only levels present in the subset
+                if (length(levs) == 0) {
+                    # fallback to no-group plot
+                    mg <- NULL
+                } else {
+                    counts <- as.integer(tab)
+                    Nmin <- min(counts)
+                sizes <- .sizesFor(Nmin)
+                sizes <- sizes[sizes >= 2]     # avoid zero or one
+                    if (length(sizes) == 0) {
+                        # fallback to no-group plot
+                        mg <- NULL
+                    }
+                }
+            }
+
+            if (is.something(mg)) {
+                for (n in sizes) {
+                    for (r in seq_len(reps)) {
+                        # Sample n per group and bind
+                        subsets <- lapply(levs, function(l) {
+                            rows <- (!is.na(gfac)) & (gfac == l)
+                            d <- alldata[rows, , drop=FALSE]
+                            if (nrow(d) < n) return(NULL)
+                            d[sample.int(nrow(d), n), , drop=FALSE]
+                        })
+                        if (any(vapply(subsets, is.null, TRUE)))
+                            next()
+                        sub <- do.call(rbind, subsets)
+                        csub <- dm$cleandata(sub, lavm$interactions)
+                        est <- Estimate$new(self$options, dm)
+                        res <- try_hard({ est$estimate(csub) })
+                        if (res$error != FALSE)
+                            next()
+                        tab <- est$tab_coefficients
+                        if (!is.something(tab))
+                            next()
+                        df <- data.frame(group = tab$lgroup, lhs = tab$lhs, rhs = tab$rhs,
+                                         p = tab$pvalue, n = n, stringsAsFactors = FALSE)
+                        out[[length(out)+1]] <- df
+                    }
+                }
+            } else {
+                N <- nrow(alldata)
+                sizes <- .sizesFor(N)
+                sizes <- sizes[sizes >= 2]
+                for (n in sizes) {
+                    if (N < n) next
+                    for (r in seq_len(reps)) {
+                        sub <- alldata[sample.int(N, n), , drop=FALSE]
+                        csub <- dm$cleandata(sub, lavm$interactions)
+                        est <- Estimate$new(self$options, dm)
+                        res <- try_hard({ est$estimate(csub) })
+                        if (res$error != FALSE)
+                            next()
+                        tab <- est$tab_coefficients
+                        if (!is.something(tab))
+                            next()
+                        df <- data.frame(group = "All", lhs = tab$lhs, rhs = tab$rhs,
+                                         p = tab$pvalue, n = n, stringsAsFactors = FALSE)
+                        out[[length(out)+1]] <- df
+                    }
+                }
+            }
+
+            if (length(out) == 0) {
+                # Fallback: use full-sample estimates so the user sees something
+                tab <- lavm$tab_coefficients
+                if (!is.something(tab)) {
+                    jmvcore::reject("Model has no regression coefficients to plot")
+                    return()
+                }
+                if (is.something(mg) && is.something(gvar) && gvar %in% names(alldata)) {
+                    gfac <- as.factor(alldata[[gvar]])
+                    gtab <- table(gfac)
+                    nper <- as.integer(gtab)
+                    names(nper) <- names(gtab)
+                    # align counts to the labels used in the coefficients table
+                    labs <- as.character(tab$lgroup)
+                    nval <- nper[match(labs, names(nper))]
+                    # replace unresolved with total N (best effort)
+                    nval[is.na(nval)] <- sum(!is.na(gfac))
+                    df <- data.frame(group = tab$lgroup, lhs = tab$lhs, rhs = tab$rhs,
+                                     p = tab$pvalue, n = as.integer(nval), stringsAsFactors = FALSE)
+                } else {
+                    N <- nrow(alldata)
+                    df <- data.frame(group = "All", lhs = tab$lhs, rhs = tab$rhs,
+                                     p = tab$pvalue, n = as.integer(N), stringsAsFactors = FALSE)
+                }
+                out[[1]] <- df
+            }
+
+            d_raw <- do.call(rbind, out)
+            # guard against zeros/negatives from underflow
+            eps <- .Machine$double.xmin
+            d_raw$p[!is.finite(d_raw$p) | is.na(d_raw$p)] <- NA
+            d_raw <- d_raw[!is.na(d_raw$p) & is.finite(d_raw$p), , drop=FALSE]
+            # summarise across replicates to get mean
+            if (nrow(d_raw) > 0) {
+                key <- d_raw[c("group","lhs","rhs","n")]
+                id <- interaction(key, drop=TRUE)
+                pmean <- tapply(d_raw$p, id, mean, na.rm=TRUE)
+                keyu <- unique(key[match(names(pmean), as.character(id)),])
+                d <- data.frame(keyu, p=as.numeric(pmean))
+                d <- d[order(d$n), , drop=FALSE]
+                # label each line as 'lhs <- rhs'
+                d$lab <- paste(d$lhs, "<-", d$rhs)
+            } else {
+                d <- d_raw
+            }
+            if (nrow(d) == 0) {
+                jmvcore::reject("No valid p-values computed for any subsample")
+                return()
+            }
+
+            ttl <- "Mean p-values vs Sample Size"
+
+            baseBreaks <- c(50, 100, 200, 500)
+            if (nrow(d) > 0) {
+                brks <- baseBreaks[baseBreaks >= min(d$n) & baseBreaks <= max(d$n)]
+                if (length(brks) == 0) brks <- sort(unique(d$n))
+            } else {
+                brks <- baseBreaks
+            }
+
+            # If this image is keyed to a specific group, filter to it
+            if (is.something(mg) && !is.null(image$state$gkey)) {
+                d <- d[d$group == image$state$gkey, , drop=FALSE]
+                ttl <- paste0(image$state$gkey, ": Mean p-values vs Sample Size")
+            }
+
+            # Build a base plot: X = sample size (n), Y = mean p-value
+            p <- ggplot2::ggplot() +
+                 ggplot2::scale_x_continuous(breaks = brks) +
+                 ggplot2::scale_y_continuous(limits = c(0, 1)) +
+                 ggplot2::geom_hline(ggplot2::aes(yintercept = 0.05, linetype = "p = 0.05"), color = "red", show.legend = TRUE) +
+                 ggplot2::scale_linetype_manual(values = c("p = 0.05" = "dashed"), name = "") +
+                 ggplot2::labs(x = "Sample size (n)", y = "Mean p-value", color = "Predictor", title = ttl) +
+                 ggplot2::theme_minimal(base_size = 12)
+
+            if (nrow(d) > 0) {
+                # draw mean line (no CI bars)
+                p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab)) +
+                        ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab))
+            } else {
+                p <- p + ggplot2::annotate("text", x = min(brks, na.rm=TRUE), y = 0.2, label = "No valid p-values to plot", hjust = 0)
+            }
+
+            print(p)
+            return(TRUE)
         },
         .marshalFormula= function(formula, data, name) {
             endogenous<-list()

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -117,16 +117,23 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             ## init p-graphs images per group (separate panels)
             if (self$options$pgraphs) {
                 images <- self$results$pgraphs$pcurves
+                tables <- self$results$pgraphs$betaci
                 if (is.something(data_machine$multigroup))  {
                     for (level in data_machine$multigroup$levels) {
                         images$addItem(level)
                         images$get(key = level)$setTitle(paste(data_machine$multigroup$var, "=", level))
                         images$get(key = level)$setState(list(gkey = level))
+                        tables$addItem(level)
+                        tables$get(key = level)$setTitle(paste(data_machine$multigroup$var, "=", level))
+                        tables$get(key = level)$setState(list(gkey = level))
                     }
                 } else {
                     images$addItem("All")
                     images$get(key = "All")$setTitle("")
                     images$get(key = "All")$setState(list(gkey = NULL))
+                    tables$addItem("All")
+                    tables$get(key = "All")$setTitle("")
+                    tables$get(key = "All")$setState(list(gkey = NULL))
                 }
             }
             
@@ -645,6 +652,63 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             }
 
             print(p)
+            return(TRUE)
+        },
+
+        .tableBetaCI=function(table, ...) {
+            if (self$options$pgraphs==FALSE)
+                return()
+
+            lavm <- private$.lav_machine
+            dm <- private$.data_machine
+            mg <- dm$multigroup
+
+            ss <- try(lavaan::standardizedSolution(lavm$model, ci=TRUE), silent=TRUE)
+            if (inherits(ss, "try-error") || is.null(ss)) {
+                return()
+            }
+            # keep only regressions
+            if ("op" %in% names(ss))
+                ss <- ss[ss$op == "~", , drop=FALSE]
+            if (nrow(ss) == 0) return()
+
+            # map group index to label
+            if (is.something(mg) && "group" %in% names(ss)) {
+                gi <- suppressWarnings(as.integer(ss$group))
+                glab <- ifelse(is.finite(gi) & gi >= 1 & gi <= length(mg$levels), as.character(mg$levels[gi]), "All")
+            } else {
+                glab <- if ("group" %in% names(ss)) as.character(ss$group) else rep("All", nrow(ss))
+            }
+
+            beta <- NA_real_
+            if ("est.std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std.all))
+            else if ("est.std" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std))
+            else if ("std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$std.all))
+
+            lower <- suppressWarnings(as.numeric(ss$ci.lower))
+            upper <- suppressWarnings(as.numeric(ss$ci.upper))
+
+            lhs <- as.character(ss$lhs)
+            rhs <- as.character(ss$rhs)
+
+            # filter per-item group
+            gkey <- if (!is.null(table$state)) table$state$gkey else NULL
+            keep <- rep(TRUE, length(lhs))
+            if (!is.null(gkey)) keep <- glab == gkey
+
+            idx <- which(keep)
+            if (length(idx) == 0) return()
+
+            for (i in idx) {
+                table$addRow(paste0("r", i), list(
+                    group = glab[i],
+                    lhs = lhs[i],
+                    rhs = rhs[i],
+                    beta = beta[i],
+                    lower = lower[i],
+                    upper = upper[i]
+                ))
+            }
             return(TRUE)
         },
         .marshalFormula= function(formula, data, name) {

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -400,7 +400,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     c(suppressWarnings(as.numeric(hit$ci.lower[1])), suppressWarnings(as.numeric(hit$ci.upper[1])))
                 }
                 rows <- list()
-                show_ci <- TRUE
+                show_ci <- isTRUE(try(self$options$pcurve_ribbons, silent=TRUE))
                 for (i in seq_len(nrow(tab))) {
                     # derive group label robustly: prefer lgroup, else map numeric group via mg$levels
                     if ("lgroup" %in% names(tab)) {

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -371,20 +371,10 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     # Guard against missing/invalid group sizes causing NA in if() condition
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
                     z0 <- as.numeric(tab$z[i])
-                    zlo0 <- z0 - 1.96
-                    zhi0 <- z0 + 1.96
                     for (n in sizes) {
-                        sq <- sqrt(n / Nobs)
-                        zn <- z0 * sq
-                        # CI for projected z based on z0 +- 1.96 at Nobs
-                        zlo_n <- zlo0 * sq
-                        zhi_n <- zhi0 * sq
-                        abs_hi <- max(abs(zlo_n), abs(zhi_n))
-                        abs_lo <- min(abs(zlo_n), abs(zhi_n))
+                        zn <- z0 * sqrt(n / Nobs)
                         p  <- 2 * stats::pnorm(-abs(zn))
-                        pu <- 2 * stats::pnorm(-abs_lo)  # upper band = larger p (smaller |z|)
-                        pl <- 2 * stats::pnorm(-abs_hi)  # lower band = smaller p (larger |z|)
-                        rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, p_l=pl, p_u=pu, beta=tab$beta[i])
+                        rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
                     }
                 }
                 d <- if (length(rows)>0) do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors=FALSE)) else NULL
@@ -393,8 +383,6 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     return()
                 }
                 d$p <- pmin(pmax(as.numeric(d$p), 0), 1)
-                if ("p_l" %in% names(d)) d$p_l <- pmin(pmax(as.numeric(d$p_l), 0), 1)
-                if ("p_u" %in% names(d)) d$p_u <- pmin(pmax(as.numeric(d$p_u), 0), 1)
                 d$n <- as.numeric(d$n)
                 d <- d[order(d$n), , drop=FALSE]
                 # label with beta per path (same within a group)
@@ -428,16 +416,10 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 .pal <- try(as.character(self$options$pcurve_palette), silent=TRUE)
                 if (is.character(.pal) && length(.pal) > 0 && .pal[1] == "okabeito") {
                     okabeito <- c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
-                    p <- p + ggplot2::scale_color_manual(values = okabeito) +
-                             ggplot2::scale_fill_manual(values = okabeito)
-                }
-                # draw 95% CI ribbons beneath lines
-                if (all(c("p_l","p_u") %in% names(d))) {
-                    p <- p + ggplot2::geom_ribbon(data=d, ggplot2::aes(x=n, ymin=p_l, ymax=p_u, fill=lab, group=lab), alpha=0.15, inherit.aes=FALSE)
+                    p <- p + ggplot2::scale_color_manual(values = okabeito)
                 }
                 p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), linetype=.lt, size=.lw) +
                         ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), size = 2)
-                p <- p + ggplot2::guides(fill = "none")
                 print(p)
                 return(TRUE)
             }

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -210,12 +210,12 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 if (is.something(private$.data_machine$multigroup)) {
                     for (level in private$.data_machine$multigroup$levels) {
                         tt <- tables$get(key = level)
-                        try(tt$clear(), silent = TRUE)
+                        
                         self$.tableBetaCI(tt, gkey=level)
                     }
                 } else {
                     tt <- tables$get(key = "All")
-                    try(tt$clear(), silent = TRUE)
+                    
                     self$.tableBetaCI(tt, gkey=NULL)
                 }
             }
@@ -716,7 +716,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             if (nrow(df) == 0)
                 return()
             # clear and fill
-            try(table$clear(), silent=TRUE)
+            
             j.fill_table(table, df)
             return(TRUE)
         },

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -336,10 +336,27 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     nmap[["All"]] <- as.numeric(nobs)
                 }
 
+                # helper to robustly resolve per-group N
+                .getNobs <- function(g) {
+                    # try mapped by group label
+                    v <- suppressWarnings(as.numeric(nmap[[g]]))
+                    if (length(v) == 0 || is.na(v) || !is.finite(v) || v <= 1) {
+                        # fallback by group index based on mg$levels position
+                        if (is.something(mg)) {
+                            pos <- which(as.character(mg$levels) %in% as.character(g))
+                            if (length(pos) == 1 && pos >= 1) {
+                                vv <- suppressWarnings(as.numeric(nobs[[pos]]))
+                                if (length(vv) > 0 && is.finite(vv) && vv > 1)
+                                    v <- vv
+                            }
+                        }
+                    }
+                    v
+                }
                 rows <- list()
                 for (i in seq_len(nrow(tab))) {
                     g <- if ("lgroup" %in% names(tab)) as.character(tab$lgroup[i]) else "All"
-                    Nobs <- suppressWarnings(as.numeric(nmap[[g]]))
+                    Nobs <- .getNobs(g)
                     # Guard against missing/invalid group sizes causing NA in if() condition
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
                     z0 <- as.numeric(tab$z[i])

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -404,13 +404,14 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 .lw <- try(as.numeric(self$options$pcurve_lwd), silent=TRUE)
                 if (!is.finite(.lw) || .lw <= 0) .lw <- 1.2
 
+                cap <- paste0("Sample sizes: ", paste(sizes, collapse=", "))
                 p <- ggplot2::ggplot() +
-                     ggplot2::scale_x_continuous(breaks = brks) +
-                     ggplot2::scale_y_continuous(limits = c(0, 1)) +
-                     ggplot2::geom_hline(ggplot2::aes(yintercept = 0.05, linetype = "p = 0.05"), color = "red", show.legend = TRUE) +
-                     ggplot2::scale_linetype_manual(values = c("p = 0.05" = "dashed"), name = "") +
-                     ggplot2::labs(x = "Sample size (n)", y = "Mean p-value", color = "Predictor", title = ttl) +
-                     ggplot2::theme_minimal(base_size = 12)
+                      ggplot2::scale_x_continuous(breaks = brks) +
+                      ggplot2::scale_y_continuous(limits = c(0, 1)) +
+                      ggplot2::geom_hline(ggplot2::aes(yintercept = 0.05, linetype = "p = 0.05"), color = "red", show.legend = TRUE) +
+                      ggplot2::scale_linetype_manual(values = c("p = 0.05" = "dashed"), name = "") +
+                      ggplot2::labs(x = "Sample size (n)", y = "Mean p-value", color = "Predictor", title = ttl, caption = cap) +
+                      ggplot2::theme_minimal(base_size = 12)
                 # palette option
                 .pal <- try(as.character(self$options$pcurve_palette), silent=TRUE)
                 if (is.character(.pal) && length(.pal) > 0 && .pal[1] == "okabeito") {

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -319,6 +319,22 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     else
                         tab$beta <- NA_real_
                 }
+                # try to obtain 95% CI for standardized effects (beta) for labelling
+                ss <- try(lavaan::standardizedSolution(lavm$model, ci=TRUE), silent=TRUE)
+                if (inherits(ss, "try-error") || is.null(ss)) {
+                    ss <- NULL
+                } else {
+                    if ("op" %in% names(ss))
+                        ss <- ss[ss$op == "~", , drop=FALSE]
+                    # map to group labels where possible
+                    if (is.something(mg) && "group" %in% names(ss)) {
+                        gi <- suppressWarnings(as.integer(ss$group))
+                        glab <- ifelse(is.finite(gi) & gi >= 1 & gi <= length(mg$levels), as.character(mg$levels[gi]), "All")
+                        ss$lgroup <- glab
+                    } else {
+                        ss$lgroup <- if ("group" %in% names(ss)) as.character(ss$group) else "All"
+                    }
+                }
                 if (!is.something(tab) || nrow(tab)==0) {
                     jmvcore::reject("Model has no regression coefficients to plot")
                     return()
@@ -353,6 +369,14 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     }
                     v
                 }
+                .getBetaCI <- function(g, lhs, rhs) {
+                    if (is.null(ss)) return(c(NA_real_, NA_real_))
+                    need <- c("lgroup","lhs","rhs","ci.lower","ci.upper")
+                    if (!all(need %in% names(ss))) return(c(NA_real_, NA_real_))
+                    hit <- ss[ss$lgroup == g & ss$lhs == lhs & ss$rhs == rhs, , drop=FALSE]
+                    if (nrow(hit) < 1) return(c(NA_real_, NA_real_))
+                    c(suppressWarnings(as.numeric(hit$ci.lower[1])), suppressWarnings(as.numeric(hit$ci.upper[1])))
+                }
                 rows <- list()
                 show_ci <- FALSE
                 for (i in seq_len(nrow(tab))) {
@@ -372,6 +396,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     # Guard against missing/invalid group sizes causing NA in if() condition
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
                     z0 <- as.numeric(tab$z[i])
+                    bci <- .getBetaCI(g, as.character(tab$lhs[i]), as.character(tab$rhs[i]))
                     if (show_ci) {
                         zlo0 <- z0 - 1.96
                         zhi0 <- z0 + 1.96
@@ -387,9 +412,11 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                             abs_lo <- min(abs(zlo_n), abs(zhi_n))
                             pu <- 2 * stats::pnorm(-abs_lo)
                             pl <- 2 * stats::pnorm(-abs_hi)
-                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
+                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p,
+                                                            beta=tab$beta[i], beta_l=bci[1], beta_u=bci[2])
                         } else {
-                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
+                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p,
+                                                            beta=tab$beta[i], beta_l=bci[1], beta_u=bci[2])
                         }
                     }
                 }
@@ -401,9 +428,14 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 d$p <- pmin(pmax(as.numeric(d$p), 0), 1)
                 d$n <- as.numeric(d$n)
                 d <- d[order(d$n), , drop=FALSE]
-                # label with beta per path (same within a group)
+                # label with beta and its 95% CI per path (same within a group)
                 fmtb <- function(x) ifelse(is.finite(x), sprintf("%.3f", x), "NA")
-                d$lab <- paste0(d$rhs, " \u2192 ", d$lhs, " (\u03B2=", fmtb(as.numeric(d$beta)), ")")
+                fmtci <- function(lo, up) {
+                    lo <- suppressWarnings(as.numeric(lo)); up <- suppressWarnings(as.numeric(up))
+                    ifelse(is.finite(lo) & is.finite(up), sprintf("[%.3f, %.3f]", lo, up), "[NA, NA]")
+                }
+                d$lab <- paste0(d$rhs, " \u2192 ", d$lhs,
+                                 " (\u03B2=", fmtb(as.numeric(d$beta)), ", 95% CI ", fmtci(d$beta_l, d$beta_u), ")")
                 d$lab <- factor(d$lab, levels = unique(d$lab))
 
                 baseBreaks <- sizes

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -355,7 +355,18 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 }
                 rows <- list()
                 for (i in seq_len(nrow(tab))) {
-                    g <- if ("lgroup" %in% names(tab)) as.character(tab$lgroup[i]) else "All"
+                    # derive group label robustly: prefer lgroup, else map numeric group via mg$levels
+                    if ("lgroup" %in% names(tab)) {
+                        g <- as.character(tab$lgroup[i])
+                    } else if ("group" %in% names(tab) && is.something(mg)) {
+                        gi <- suppressWarnings(as.integer(tab$group[i]))
+                        if (is.finite(gi) && gi >= 1 && gi <= length(mg$levels))
+                            g <- as.character(mg$levels[[gi]])
+                        else
+                            g <- "All"
+                    } else {
+                        g <- "All"
+                    }
                     Nobs <- .getNobs(g)
                     # Guard against missing/invalid group sizes causing NA in if() condition
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -123,17 +123,11 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                         images$addItem(level)
                         images$get(key = level)$setTitle(paste(data_machine$multigroup$var, "=", level))
                         images$get(key = level)$setState(list(gkey = level))
-
-)
-)
                     }
                 } else {
                     images$addItem("All")
                     images$get(key = "All")$setTitle("")
                     images$get(key = "All")$setState(list(gkey = NULL))
-
-
-)
                 }
             }
             

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -211,12 +211,12 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     for (level in private$.data_machine$multigroup$levels) {
                         tt <- tables$get(key = level)
                         try(tt$clear(), silent = TRUE)
-                        self$.tableBetaCI(tt)
+                        self$.tableBetaCI(tt, gkey=level)
                     }
                 } else {
                     tt <- tables$get(key = "All")
                     try(tt$clear(), silent = TRUE)
-                    self$.tableBetaCI(tt)
+                    self$.tableBetaCI(tt, gkey=NULL)
                 }
             }
 
@@ -680,60 +680,44 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             return(TRUE)
         },
 
-        .tableBetaCI=function(table, ...) {
+        .tableBetaCI=function(table, gkey=NULL, ...) {
             if (self$options$pgraphs==FALSE)
                 return()
-
             lavm <- private$.lav_machine
             dm <- private$.data_machine
             mg <- dm$multigroup
-
-            ss <- try(lavaan::standardizedSolution(lavm$model, ci=TRUE), silent=TRUE)
-            if (inherits(ss, "try-error") || is.null(ss)) {
+            ss <- try(lavaan::standardizedSolution(lavm$model, ci=TRUE, se=TRUE, level=self$options$ciWidth/100), silent=TRUE)
+            if (inherits(ss, "try-error") || is.null(ss))
                 return()
-            }
-            # keep only regressions
             if ("op" %in% names(ss))
                 ss <- ss[ss$op == "~", , drop=FALSE]
-            if (nrow(ss) == 0) return()
-
-            # map group index to label
+            if (nrow(ss) == 0)
+                return()
+            # decode names if they are base64-encoded
+            lhs <- as.character(fromb64(ss$lhs))
+            rhs <- as.character(fromb64(ss$rhs))
+            # groups
             if (is.something(mg) && "group" %in% names(ss)) {
                 gi <- suppressWarnings(as.integer(ss$group))
                 glab <- ifelse(is.finite(gi) & gi >= 1 & gi <= length(mg$levels), as.character(mg$levels[gi]), "All")
             } else {
                 glab <- if ("group" %in% names(ss)) as.character(ss$group) else rep("All", nrow(ss))
             }
-
+            # standardized beta and CI
             beta <- NA_real_
-            if ("est.std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std.all))
-            else if ("est.std" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std))
-            else if ("std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$std.all))
-
+            if ("est.std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std.all)) else
+            if ("est.std" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std)) else
+            if ("std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$std.all))
             lower <- suppressWarnings(as.numeric(ss$ci.lower))
             upper <- suppressWarnings(as.numeric(ss$ci.upper))
-
-            lhs <- as.character(ss$lhs)
-            rhs <- as.character(ss$rhs)
-
-            # filter per-item group
-            gkey <- if (!is.null(table$state)) table$state$gkey else NULL
-            keep <- rep(TRUE, length(lhs))
-            if (!is.null(gkey)) keep <- glab == gkey
-
-            idx <- which(keep)
-            if (length(idx) == 0) return()
-
-            for (i in idx) {
-                table$addRow(paste0("r", i), list(
-                    group = glab[i],
-                    lhs = lhs[i],
-                    rhs = rhs[i],
-                    beta = beta[i],
-                    lower = lower[i],
-                    upper = upper[i]
-                ))
-            }
+            df <- data.frame(group=glab, lhs=lhs, rhs=rhs, beta=beta, lower=lower, upper=upper, stringsAsFactors=FALSE)
+            if (!is.null(gkey))
+                df <- df[df$group == gkey, , drop=FALSE]
+            if (nrow(df) == 0)
+                return()
+            # clear and fill
+            try(table$clear(), silent=TRUE)
+            j.fill_table(table, df)
             return(TRUE)
         },
         .marshalFormula= function(formula, data, name) {

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -354,7 +354,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     v
                 }
                 rows <- list()
-                show_ci <- isTRUE(try(self$options$pcurve_ci, silent=TRUE))
+                show_ci <- FALSE
                 for (i in seq_len(nrow(tab))) {
                     # derive group label robustly: prefer lgroup, else map numeric group via mg$levels
                     if ("lgroup" %in% names(tab)) {
@@ -387,7 +387,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                             abs_lo <- min(abs(zlo_n), abs(zhi_n))
                             pu <- 2 * stats::pnorm(-abs_lo)
                             pl <- 2 * stats::pnorm(-abs_hi)
-                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, p_l=pl, p_u=pu, beta=tab$beta[i])
+                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
                         } else {
                             rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
                         }
@@ -436,13 +436,9 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     labs <- levels(d$lab)
                     vals <- rep(okabeito, length.out=length(labs))
                     names(vals) <- labs
-                    p <- p + ggplot2::scale_color_manual(values = vals) +
-                             ggplot2::scale_fill_manual(values = vals)
+                    p <- p + ggplot2::scale_color_manual(values = vals)
                 }
-                if (isTRUE(show_ci) && all(c("p_l","p_u") %in% names(d))) {
-                    p <- p + ggplot2::geom_ribbon(data=d, ggplot2::aes(x=n, ymin=p_l, ymax=p_u, fill=lab, group=lab), alpha=0.15, inherit.aes=FALSE) +
-                            ggplot2::guides(fill = "none")
-                }
+                
                 p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), linetype=.lt, size=.lw) +
                         ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), size = 2)
                 print(p)

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -198,21 +198,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             if (self$options$showintercepts)
                    j.fill_table(self$results$models$intercepts,lav_machine$tab_intercepts)
 
-            # populate per-group standardized beta CI tables under P-Value Graphs
-            if (isTRUE(self$options$pgraphs)) {
-
-                if (is.something(private$.data_machine$multigroup)) {
-                    for (level in private$.data_machine$multigroup$levels) {
-                        tt <- tables$get(key = level)
-                        
-                        private$.tableBetaCI(tt, gkey=level)
-                    }
-                } else {
-                    tt <- tables$get(key = "All")
-                    
-                    private$.tableBetaCI(tt, gkey=NULL)
-                }
-            }
+            # standardized beta CI tables removed
 
             ## diagrams
             private$.plot_machine$preparePlots()   

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -385,7 +385,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     c(suppressWarnings(as.numeric(hit$ci.lower[1])), suppressWarnings(as.numeric(hit$ci.upper[1])))
                 }
                 rows <- list()
-                show_ci <- FALSE
+                show_ci <- TRUE
                 for (i in seq_len(nrow(tab))) {
                     # derive group label robustly: prefer lgroup, else map numeric group via mg$levels
                     if ("lgroup" %in% names(tab)) {
@@ -404,14 +404,14 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
                     z0 <- as.numeric(tab$z[i])
                     bci <- .getBetaCI(g, as.character(tab$lhs[i]), as.character(tab$rhs[i]))
-                    if (show_ci) {
-                        zlo0 <- z0 - 1.96
-                        zhi0 <- z0 + 1.96
-                    }
-                    for (n in sizes) {
-                        sq <- sqrt(n / Nobs)
-                        zn <- z0 * sq
-                        p  <- 2 * stats::pnorm(-abs(zn))
+                        if (show_ci) {
+                            zlo0 <- z0 - 1.96
+                            zhi0 <- z0 + 1.96
+                        }
+                        for (n in sizes) {
+                            sq <- sqrt(n / Nobs)
+                            zn <- z0 * sq
+                            p  <- 2 * stats::pnorm(-abs(zn))
                         if (show_ci) {
                             zlo_n <- zlo0 * sq
                             zhi_n <- zhi0 * sq
@@ -420,7 +420,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                             pu <- 2 * stats::pnorm(-abs_lo)
                             pl <- 2 * stats::pnorm(-abs_hi)
                             rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p,
-                                                            beta=tab$beta[i], beta_l=bci[1], beta_u=bci[2])
+                                                            p_l=pl, p_u=pu, beta=tab$beta[i], beta_l=bci[1], beta_u=bci[2])
                         } else {
                             rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p,
                                                             beta=tab$beta[i], beta_l=bci[1], beta_u=bci[2])
@@ -433,6 +433,8 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     return()
                 }
                 d$p <- pmin(pmax(as.numeric(d$p), 0), 1)
+                if ("p_l" %in% names(d)) d$p_l <- pmin(pmax(as.numeric(d$p_l), 0), 1)
+                if ("p_u" %in% names(d)) d$p_u <- pmin(pmax(as.numeric(d$p_u), 0), 1)
                 d$n <- as.numeric(d$n)
                 d <- d[order(d$n), , drop=FALSE]
                 # label with beta and its 95% CI per path (same within a group)
@@ -468,15 +470,23 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                       ggplot2::scale_linetype_manual(values = c("p = 0.05" = "dashed"), name = "") +
                       ggplot2::labs(x = "Sample size (n)", y = "Mean p-value", color = "Predictor", title = ttl, caption = cap) +
                       ggplot2::theme_minimal(base_size = 12)
-                # palette option
+                # palette + optional ribbons
                 .pal <- try(as.character(self$options$pcurve_palette), silent=TRUE)
-                if (is.character(.pal) && length(.pal) > 0 && .pal[1] == "okabeito") {
-                    okabeito <- c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
-                    labs <- levels(d$lab)
-                    vals <- rep(okabeito, length.out=length(labs))
-                    names(vals) <- labs
-                    p <- p + ggplot2::scale_color_manual(values = vals)
+                labs <- levels(d$lab)
+                if (!is.character(.pal) || length(.pal) == 0) .pal <- "default"
+                if (.pal[1] == "okabeito") {
+                    vals <- c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
+                    vals <- rep(vals, length.out=length(labs))
+                } else {
+                    vals <- try(scales::hue_pal()(length(labs)), silent=TRUE)
+                    if (inherits(vals, "try-error"))
+                        vals <- grDevices::hcl(h=seq(15, 375, length.out=length(labs)+1)[1:length(labs)], c=100, l=65)
                 }
+                names(vals) <- labs
+                p <- p + ggplot2::scale_color_manual(values = vals) + ggplot2::scale_fill_manual(values = vals)
+                if (all(c("p_l","p_u") %in% names(d)))
+                    p <- p + ggplot2::geom_ribbon(data=d, ggplot2::aes(x=n, ymin=p_l, ymax=p_u, fill=lab, group=lab), alpha=0.15, inherit.aes=FALSE) +
+                             ggplot2::guides(fill = "none")
                 
                 p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), linetype=.lt, size=.lw) +
                         ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), size = 2)

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -117,23 +117,23 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             ## init p-graphs images per group (separate panels)
             if (self$options$pgraphs) {
                 images <- self$results$pgraphs$pcurves
-                tables <- self$results$pgraphs$betaci
+
                 if (is.something(data_machine$multigroup))  {
                     for (level in data_machine$multigroup$levels) {
                         images$addItem(level)
                         images$get(key = level)$setTitle(paste(data_machine$multigroup$var, "=", level))
                         images$get(key = level)$setState(list(gkey = level))
-                        tables$addItem(level)
-                        tables$get(key = level)$setTitle(paste(data_machine$multigroup$var, "=", level))
-                        tables$get(key = level)$setState(list(gkey = level))
+
+)
+)
                     }
                 } else {
                     images$addItem("All")
                     images$get(key = "All")$setTitle("")
                     images$get(key = "All")$setState(list(gkey = NULL))
-                    tables$addItem("All")
-                    tables$get(key = "All")$setTitle("")
-                    tables$get(key = "All")$setState(list(gkey = NULL))
+
+
+)
                 }
             }
             
@@ -206,17 +206,17 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
 
             # populate per-group standardized beta CI tables under P-Value Graphs
             if (isTRUE(self$options$pgraphs)) {
-                tables <- self$results$pgraphs$betaci
+
                 if (is.something(private$.data_machine$multigroup)) {
                     for (level in private$.data_machine$multigroup$levels) {
                         tt <- tables$get(key = level)
                         
-                        self$.tableBetaCI(tt, gkey=level)
+                        private$.tableBetaCI(tt, gkey=level)
                     }
                 } else {
                     tt <- tables$get(key = "All")
                     
-                    self$.tableBetaCI(tt, gkey=NULL)
+                    private$.tableBetaCI(tt, gkey=NULL)
                 }
             }
 
@@ -680,46 +680,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             return(TRUE)
         },
 
-        .tableBetaCI=function(table, gkey=NULL, ...) {
-            if (self$options$pgraphs==FALSE)
-                return()
-            lavm <- private$.lav_machine
-            dm <- private$.data_machine
-            mg <- dm$multigroup
-            ss <- try(lavaan::standardizedSolution(lavm$model, ci=TRUE, se=TRUE, level=self$options$ciWidth/100), silent=TRUE)
-            if (inherits(ss, "try-error") || is.null(ss))
-                return()
-            if ("op" %in% names(ss))
-                ss <- ss[ss$op == "~", , drop=FALSE]
-            if (nrow(ss) == 0)
-                return()
-            # decode names if they are base64-encoded
-            lhs <- as.character(fromb64(ss$lhs))
-            rhs <- as.character(fromb64(ss$rhs))
-            # groups
-            if (is.something(mg) && "group" %in% names(ss)) {
-                gi <- suppressWarnings(as.integer(ss$group))
-                glab <- ifelse(is.finite(gi) & gi >= 1 & gi <= length(mg$levels), as.character(mg$levels[gi]), "All")
-            } else {
-                glab <- if ("group" %in% names(ss)) as.character(ss$group) else rep("All", nrow(ss))
-            }
-            # standardized beta and CI
-            beta <- NA_real_
-            if ("est.std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std.all)) else
-            if ("est.std" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$est.std)) else
-            if ("std.all" %in% names(ss)) beta <- suppressWarnings(as.numeric(ss$std.all))
-            lower <- suppressWarnings(as.numeric(ss$ci.lower))
-            upper <- suppressWarnings(as.numeric(ss$ci.upper))
-            df <- data.frame(group=glab, lhs=lhs, rhs=rhs, beta=beta, lower=lower, upper=upper, stringsAsFactors=FALSE)
-            if (!is.null(gkey))
-                df <- df[df$group == gkey, , drop=FALSE]
-            if (nrow(df) == 0)
-                return()
-            # clear and fill
-            
-            j.fill_table(table, df)
-            return(TRUE)
-        },
+        
         .marshalFormula= function(formula, data, name) {
             endogenous<-list()
             endogenousTerms<-list()
@@ -798,3 +759,4 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
         
         )
 )
+

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -371,10 +371,20 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     # Guard against missing/invalid group sizes causing NA in if() condition
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
                     z0 <- as.numeric(tab$z[i])
+                    zlo0 <- z0 - 1.96
+                    zhi0 <- z0 + 1.96
                     for (n in sizes) {
-                        zn <- z0 * sqrt(n / Nobs)
-                        p <- 2 * stats::pnorm(-abs(zn))
-                        rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
+                        sq <- sqrt(n / Nobs)
+                        zn <- z0 * sq
+                        # CI for projected z based on z0 +- 1.96 at Nobs
+                        zlo_n <- zlo0 * sq
+                        zhi_n <- zhi0 * sq
+                        abs_hi <- max(abs(zlo_n), abs(zhi_n))
+                        abs_lo <- min(abs(zlo_n), abs(zhi_n))
+                        p  <- 2 * stats::pnorm(-abs(zn))
+                        pu <- 2 * stats::pnorm(-abs_lo)  # upper band = larger p (smaller |z|)
+                        pl <- 2 * stats::pnorm(-abs_hi)  # lower band = smaller p (larger |z|)
+                        rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, p_l=pl, p_u=pu, beta=tab$beta[i])
                     }
                 }
                 d <- if (length(rows)>0) do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors=FALSE)) else NULL
@@ -383,6 +393,8 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     return()
                 }
                 d$p <- pmin(pmax(as.numeric(d$p), 0), 1)
+                if ("p_l" %in% names(d)) d$p_l <- pmin(pmax(as.numeric(d$p_l), 0), 1)
+                if ("p_u" %in% names(d)) d$p_u <- pmin(pmax(as.numeric(d$p_u), 0), 1)
                 d$n <- as.numeric(d$n)
                 d <- d[order(d$n), , drop=FALSE]
                 # label with beta per path (same within a group)
@@ -416,10 +428,16 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 .pal <- try(as.character(self$options$pcurve_palette), silent=TRUE)
                 if (is.character(.pal) && length(.pal) > 0 && .pal[1] == "okabeito") {
                     okabeito <- c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
-                    p <- p + ggplot2::scale_color_manual(values = okabeito)
+                    p <- p + ggplot2::scale_color_manual(values = okabeito) +
+                             ggplot2::scale_fill_manual(values = okabeito)
+                }
+                # draw 95% CI ribbons beneath lines
+                if (all(c("p_l","p_u") %in% names(d))) {
+                    p <- p + ggplot2::geom_ribbon(data=d, ggplot2::aes(x=n, ymin=p_l, ymax=p_u, fill=lab, group=lab), alpha=0.15, inherit.aes=FALSE)
                 }
                 p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), linetype=.lt, size=.lw) +
                         ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), size = 2)
+                p <- p + ggplot2::guides(fill = "none")
                 print(p)
                 return(TRUE)
             }

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -354,6 +354,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     v
                 }
                 rows <- list()
+                show_ci <- isTRUE(try(self$options$pcurve_ci, silent=TRUE))
                 for (i in seq_len(nrow(tab))) {
                     # derive group label robustly: prefer lgroup, else map numeric group via mg$levels
                     if ("lgroup" %in% names(tab)) {
@@ -371,10 +372,25 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                     # Guard against missing/invalid group sizes causing NA in if() condition
                     if (length(Nobs) == 0 || is.na(Nobs) || !is.finite(Nobs) || Nobs <= 1) next
                     z0 <- as.numeric(tab$z[i])
+                    if (show_ci) {
+                        zlo0 <- z0 - 1.96
+                        zhi0 <- z0 + 1.96
+                    }
                     for (n in sizes) {
-                        zn <- z0 * sqrt(n / Nobs)
+                        sq <- sqrt(n / Nobs)
+                        zn <- z0 * sq
                         p  <- 2 * stats::pnorm(-abs(zn))
-                        rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
+                        if (show_ci) {
+                            zlo_n <- zlo0 * sq
+                            zhi_n <- zhi0 * sq
+                            abs_hi <- max(abs(zlo_n), abs(zhi_n))
+                            abs_lo <- min(abs(zlo_n), abs(zhi_n))
+                            pu <- 2 * stats::pnorm(-abs_lo)
+                            pl <- 2 * stats::pnorm(-abs_hi)
+                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, p_l=pl, p_u=pu, beta=tab$beta[i])
+                        } else {
+                            rows[[length(rows)+1]] <- list(group=g, lhs=tab$lhs[i], rhs=tab$rhs[i], n=n, p=p, beta=tab$beta[i])
+                        }
                     }
                 }
                 d <- if (length(rows)>0) do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors=FALSE)) else NULL
@@ -388,6 +404,7 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 # label with beta per path (same within a group)
                 fmtb <- function(x) ifelse(is.finite(x), sprintf("%.3f", x), "NA")
                 d$lab <- paste0(d$rhs, " \u2192 ", d$lhs, " (\u03B2=", fmtb(as.numeric(d$beta)), ")")
+                d$lab <- factor(d$lab, levels = unique(d$lab))
 
                 baseBreaks <- sizes
                 brks <- baseBreaks
@@ -416,7 +433,15 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
                 .pal <- try(as.character(self$options$pcurve_palette), silent=TRUE)
                 if (is.character(.pal) && length(.pal) > 0 && .pal[1] == "okabeito") {
                     okabeito <- c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
-                    p <- p + ggplot2::scale_color_manual(values = okabeito)
+                    labs <- levels(d$lab)
+                    vals <- rep(okabeito, length.out=length(labs))
+                    names(vals) <- labs
+                    p <- p + ggplot2::scale_color_manual(values = vals) +
+                             ggplot2::scale_fill_manual(values = vals)
+                }
+                if (isTRUE(show_ci) && all(c("p_l","p_u") %in% names(d))) {
+                    p <- p + ggplot2::geom_ribbon(data=d, ggplot2::aes(x=n, ymin=p_l, ymax=p_u, fill=lab, group=lab), alpha=0.15, inherit.aes=FALSE) +
+                            ggplot2::guides(fill = "none")
                 }
                 p <- p + ggplot2::geom_line(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), linetype=.lt, size=.lw) +
                         ggplot2::geom_point(data=d, ggplot2::aes(x = n, y = p, color = lab, group = lab), size = 2)

--- a/R/pathj.b.R
+++ b/R/pathj.b.R
@@ -203,7 +203,22 @@ pathjClass <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Class(
             
             if (self$options$showintercepts)
                    j.fill_table(self$results$models$intercepts,lav_machine$tab_intercepts)
-            
+
+            # populate per-group standardized beta CI tables under P-Value Graphs
+            if (isTRUE(self$options$pgraphs)) {
+                tables <- self$results$pgraphs$betaci
+                if (is.something(private$.data_machine$multigroup)) {
+                    for (level in private$.data_machine$multigroup$levels) {
+                        tt <- tables$get(key = level)
+                        try(tt$clear(), silent = TRUE)
+                        self$.tableBetaCI(tt)
+                    }
+                } else {
+                    tt <- tables$get(key = "All")
+                    try(tt$clear(), silent = TRUE)
+                    self$.tableBetaCI(tt)
+                }
+            }
 
             ## diagrams
             private$.plot_machine$preparePlots()   

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -30,10 +30,11 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 list()),
             diagram = FALSE,
             pgraphs = FALSE,
-            pcurve_sizes = '50, 100, 200, 500',
+            pcurve_sizes = "50, 100, 200, 500",
             pcurve_linetype = "solid",
             pcurve_lwd = 1.2,
             pcurve_palette = "default",
+            pcurve_ci = FALSE,
             diag_paths = "est",
             diag_resid = FALSE,
             diag_offset_labs = FALSE,
@@ -238,7 +239,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             private$..pcurve_sizes <- jmvcore::OptionString$new(
                 "pcurve_sizes",
                 pcurve_sizes,
-                default='50, 100, 200, 500')
+                default="50, 100, 200, 500")
             private$..pcurve_linetype <- jmvcore::OptionList$new(
                 "pcurve_linetype",
                 pcurve_linetype,
@@ -250,9 +251,9 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             private$..pcurve_lwd <- jmvcore::OptionNumber$new(
                 "pcurve_lwd",
                 pcurve_lwd,
+                default=1.2,
                 min=0.2,
-                max=5,
-                default=1.2)
+                max=5)
             private$..pcurve_palette <- jmvcore::OptionList$new(
                 "pcurve_palette",
                 pcurve_palette,
@@ -260,6 +261,10 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "default",
                     "okabeito"),
                 default="default")
+            private$..pcurve_ci <- jmvcore::OptionBool$new(
+                "pcurve_ci",
+                pcurve_ci,
+                default=FALSE)
             private$..diag_paths <- jmvcore::OptionList$new(
                 "diag_paths",
                 diag_paths,
@@ -411,6 +416,10 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             self$.addOption(private$..endogenousTerms)
             self$.addOption(private$..diagram)
             self$.addOption(private$..pgraphs)
+            self$.addOption(private$..pcurve_sizes)
+            self$.addOption(private$..pcurve_linetype)
+            self$.addOption(private$..pcurve_lwd)
+            self$.addOption(private$..pcurve_palette)
             self$.addOption(private$..diag_paths)
             self$.addOption(private$..diag_resid)
             self$.addOption(private$..diag_offset_labs)
@@ -459,6 +468,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         pcurve_linetype = function() private$..pcurve_linetype$value,
         pcurve_lwd = function() private$..pcurve_lwd$value,
         pcurve_palette = function() private$..pcurve_palette$value,
+        pcurve_ci = function() private$..pcurve_ci$value,
         diag_paths = function() private$..diag_paths$value,
         diag_resid = function() private$..diag_resid$value,
         diag_offset_labs = function() private$..diag_offset_labs$value,
@@ -506,6 +516,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         ..pcurve_linetype = NA,
         ..pcurve_lwd = NA,
         ..pcurve_palette = NA,
+        ..pcurve_ci = NA,
         ..diag_paths = NA,
         ..diag_resid = NA,
         ..diag_offset_labs = NA,
@@ -1267,7 +1278,12 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     "endogenousTerms",
                                     "data",
                                     "varcov",
-                                    "cov_y"))))}))$new(options=options))
+                                    "cov_y",
+                                    "pgraphs",
+                                    "pcurve_sizes",
+                                    "pcurve_linetype",
+                                    "pcurve_lwd",
+                                    "pcurve_palette"))))}))$new(options=options))
             self$add(jmvcore::Table$new(
                 options=options,
                 name="contraintsnotes",

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -34,6 +34,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             pcurve_linetype = "solid",
             pcurve_lwd = 1.2,
             pcurve_palette = "default",
+            pcurve_ribbons = TRUE,
             diag_paths = "est",
             diag_resid = FALSE,
             diag_offset_labs = FALSE,
@@ -260,6 +261,10 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "default",
                     "okabeito"),
                 default="default")
+            private$..pcurve_ribbons <- jmvcore::OptionBool$new(
+                "pcurve_ribbons",
+                pcurve_ribbons,
+                default=TRUE)
             private$..diag_paths <- jmvcore::OptionList$new(
                 "diag_paths",
                 diag_paths,
@@ -463,6 +468,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         pcurve_linetype = function() private$..pcurve_linetype$value,
         pcurve_lwd = function() private$..pcurve_lwd$value,
         pcurve_palette = function() private$..pcurve_palette$value,
+        pcurve_ribbons = function() private$..pcurve_ribbons$value,
         diag_paths = function() private$..diag_paths$value,
         diag_resid = function() private$..diag_resid$value,
         diag_offset_labs = function() private$..diag_offset_labs$value,
@@ -510,6 +516,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         ..pcurve_linetype = NA,
         ..pcurve_lwd = NA,
         ..pcurve_palette = NA,
+        ..pcurve_ribbons = NA,
         ..diag_paths = NA,
         ..diag_resid = NA,
         ..diag_offset_labs = NA,
@@ -1362,4 +1369,3 @@ pathjBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 requiresMissings = FALSE,
                 weightsSupport = 'auto')
         }))
-

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -29,6 +29,11 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             endogenousTerms = list(
                 list()),
             diagram = FALSE,
+            pgraphs = FALSE,
+            pcurve_sizes = '50, 100, 200, 500',
+            pcurve_linetype = "solid",
+            pcurve_lwd = 1.2,
+            pcurve_palette = "default",
             diag_paths = "est",
             diag_resid = FALSE,
             diag_offset_labs = FALSE,
@@ -226,6 +231,35 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 "diagram",
                 diagram,
                 default=FALSE)
+            private$..pgraphs <- jmvcore::OptionBool$new(
+                "pgraphs",
+                pgraphs,
+                default=FALSE)
+            private$..pcurve_sizes <- jmvcore::OptionString$new(
+                "pcurve_sizes",
+                pcurve_sizes,
+                default='50, 100, 200, 500')
+            private$..pcurve_linetype <- jmvcore::OptionList$new(
+                "pcurve_linetype",
+                pcurve_linetype,
+                options=list(
+                    "solid",
+                    "dashed",
+                    "dotted"),
+                default="solid")
+            private$..pcurve_lwd <- jmvcore::OptionNumber$new(
+                "pcurve_lwd",
+                pcurve_lwd,
+                min=0.2,
+                max=5,
+                default=1.2)
+            private$..pcurve_palette <- jmvcore::OptionList$new(
+                "pcurve_palette",
+                pcurve_palette,
+                options=list(
+                    "default",
+                    "okabeito"),
+                default="default")
             private$..diag_paths <- jmvcore::OptionList$new(
                 "diag_paths",
                 diag_paths,
@@ -376,6 +410,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             self$.addOption(private$..scaling)
             self$.addOption(private$..endogenousTerms)
             self$.addOption(private$..diagram)
+            self$.addOption(private$..pgraphs)
             self$.addOption(private$..diag_paths)
             self$.addOption(private$..diag_resid)
             self$.addOption(private$..diag_offset_labs)
@@ -419,6 +454,11 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         scaling = function() private$..scaling$value,
         endogenousTerms = function() private$..endogenousTerms$value,
         diagram = function() private$..diagram$value,
+        pgraphs = function() private$..pgraphs$value,
+        pcurve_sizes = function() private$..pcurve_sizes$value,
+        pcurve_linetype = function() private$..pcurve_linetype$value,
+        pcurve_lwd = function() private$..pcurve_lwd$value,
+        pcurve_palette = function() private$..pcurve_palette$value,
         diag_paths = function() private$..diag_paths$value,
         diag_resid = function() private$..diag_resid$value,
         diag_offset_labs = function() private$..diag_offset_labs$value,
@@ -461,6 +501,11 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         ..scaling = NA,
         ..endogenousTerms = NA,
         ..diagram = NA,
+        ..pgraphs = NA,
+        ..pcurve_sizes = NA,
+        ..pcurve_linetype = NA,
+        ..pcurve_lwd = NA,
+        ..pcurve_palette = NA,
         ..diag_paths = NA,
         ..diag_resid = NA,
         ..diag_offset_labs = NA,
@@ -492,6 +537,7 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         diagnostics = function() private$.items[["diagnostics"]],
         models = function() private$.items[["models"]],
         pathgroup = function() private$.items[["pathgroup"]],
+        pgraphs = function() private$.items[["pgraphs"]],
         contraintsnotes = function() private$.items[["contraintsnotes"]]),
     private = list(
         ..model = NA),
@@ -1183,6 +1229,45 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     `name`="message", 
                                     `type`="text", 
                                     `title`="Model diagram notes"))))}))$new(options=options))
+            self$add(R6::R6Class(
+                inherit = jmvcore::Group,
+                active = list(
+                    pcurves = function() private$.items[["pcurves"]]),
+                private = list(),
+                public=list(
+                    initialize=function(options) {
+                        super$initialize(
+                            options=options,
+                            name="pgraphs",
+                            title="P-Value Graphs",
+                            clearWith=list(
+                    "endogenous",
+                    "cov_y",
+                    "constraints",
+                    "varcov",
+                    "data",
+                    "multigroup"))
+                        self$add(jmvcore::Array$new(
+                            options=options,
+                            name="pcurves",
+                            title="P-Value Curves",
+                            visible="(pgraphs)",
+                            template=jmvcore::Image$new(
+                                options=options,
+                                title="$key",
+                                renderFun=".plotPvalues",
+                                width=900,
+                                height=500,
+                                clearWith=list(
+                                    "endogenous",
+                                    "covs",
+                                    "factors",
+                                    "multigroup",
+                                    "constraints",
+                                    "endogenousTerms",
+                                    "data",
+                                    "varcov",
+                                    "cov_y"))))}))$new(options=options))
             self$add(jmvcore::Table$new(
                 options=options,
                 name="contraintsnotes",
@@ -1223,4 +1308,3 @@ pathjBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 requiresMissings = FALSE,
                 weightsSupport = 'auto')
         }))
-

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -34,7 +34,6 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             pcurve_linetype = "solid",
             pcurve_lwd = 1.2,
             pcurve_palette = "default",
-            pcurve_ci = FALSE,
             diag_paths = "est",
             diag_resid = FALSE,
             diag_offset_labs = FALSE,
@@ -261,10 +260,6 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "default",
                     "okabeito"),
                 default="default")
-            private$..pcurve_ci <- jmvcore::OptionBool$new(
-                "pcurve_ci",
-                pcurve_ci,
-                default=FALSE)
             private$..diag_paths <- jmvcore::OptionList$new(
                 "diag_paths",
                 diag_paths,
@@ -468,7 +463,6 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         pcurve_linetype = function() private$..pcurve_linetype$value,
         pcurve_lwd = function() private$..pcurve_lwd$value,
         pcurve_palette = function() private$..pcurve_palette$value,
-        pcurve_ci = function() private$..pcurve_ci$value,
         diag_paths = function() private$..diag_paths$value,
         diag_resid = function() private$..diag_resid$value,
         diag_offset_labs = function() private$..diag_offset_labs$value,
@@ -516,7 +510,6 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         ..pcurve_linetype = NA,
         ..pcurve_lwd = NA,
         ..pcurve_palette = NA,
-        ..pcurve_ci = NA,
         ..diag_paths = NA,
         ..diag_resid = NA,
         ..diag_offset_labs = NA,
@@ -1324,3 +1317,4 @@ pathjBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 requiresMissings = FALSE,
                 weightsSupport = 'auto')
         }))
+

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -420,6 +420,7 @@ pathjOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             self$.addOption(private$..pcurve_linetype)
             self$.addOption(private$..pcurve_lwd)
             self$.addOption(private$..pcurve_palette)
+            self$.addOption(private$..pcurve_ribbons)
             self$.addOption(private$..diag_paths)
             self$.addOption(private$..diag_resid)
             self$.addOption(private$..diag_offset_labs)
@@ -1243,8 +1244,7 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             self$add(R6::R6Class(
                 inherit = jmvcore::Group,
                 active = list(
-                    pcurves = function() private$.items[["pcurves"]],
-                    betaci = function() private$.items[["betaci"]]),
+                    pcurves = function() private$.items[["pcurves"]]),
                 private = list(),
                 public=list(
                     initialize=function(options) {
@@ -1284,51 +1284,8 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     "pcurve_sizes",
                                     "pcurve_linetype",
                                     "pcurve_lwd",
-                                    "pcurve_palette"))))
-                        self$add(jmvcore::Array$new(
-                            options=options,
-                            name="betaci",
-                            title="Standardized Effects (\u03B2) \u2013 95% CI",
-                            visible="(pgraphs)",
-                            template=jmvcore::Table$new(
-                                options=options,
-                                title="$key",
-                                clearWith=list(
-                                    "endogenous",
-                                    "covs",
-                                    "factors",
-                                    "multigroup",
-                                    "constraints",
-                                    "endogenousTerms",
-                                    "data",
-                                    "varcov",
-                                    "cov_y",
-                                    "pgraphs"),
-                                columns=list(
-                                    list(
-                                        `name`="group", 
-                                        `type`="text", 
-                                        `title`="Group"),
-                                    list(
-                                        `name`="lhs", 
-                                        `type`="text", 
-                                        `title`="Dep"),
-                                    list(
-                                        `name`="rhs", 
-                                        `type`="text", 
-                                        `title`="Pred"),
-                                    list(
-                                        `name`="beta", 
-                                        `type`="number", 
-                                        `title`="\u03B2"),
-                                    list(
-                                        `name`="lower", 
-                                        `type`="number", 
-                                        `title`="Lower"),
-                                    list(
-                                        `name`="upper", 
-                                        `type`="number", 
-                                        `title`="Upper")))))}))$new(options=options))
+                                    "pcurve_palette",
+                                    "pcurve_ribbons")))))}))$new(options=options))
             self$add(jmvcore::Table$new(
                 options=options,
                 name="contraintsnotes",

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -1236,7 +1236,8 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             self$add(R6::R6Class(
                 inherit = jmvcore::Group,
                 active = list(
-                    pcurves = function() private$.items[["pcurves"]]),
+                    pcurves = function() private$.items[["pcurves"]],
+                    betaci = function() private$.items[["betaci"]]),
                 private = list(),
                 public=list(
                     initialize=function(options) {
@@ -1276,16 +1277,15 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     "pcurve_sizes",
                                     "pcurve_linetype",
                                     "pcurve_lwd",
-                                     "pcurve_palette"))))
+                                    "pcurve_palette"))))
                         self$add(jmvcore::Array$new(
                             options=options,
                             name="betaci",
-                            title="Standardized Effects (β) – 95% CI",
+                            title="Standardized Effects (\u03B2) \u2013 95% CI",
                             visible="(pgraphs)",
                             template=jmvcore::Table$new(
                                 options=options,
                                 title="$key",
-                                renderFun=".tableBetaCI",
                                 clearWith=list(
                                     "endogenous",
                                     "covs",
@@ -1298,12 +1298,30 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     "cov_y",
                                     "pgraphs"),
                                 columns=list(
-                                    list(`name`="group", `type`="text", `title`="Group"),
-                                    list(`name`="lhs", `type`="text", `title`="Dep"),
-                                    list(`name`="rhs", `type`="text", `title`="Pred"),
-                                    list(`name`="beta", `type`="number", `title`="β"),
-                                    list(`name`="lower", `type`="number", `title`="Lower"),
-                                    list(`name`="upper", `type`="number", `title`="Upper"))))))}))$new(options=options))
+                                    list(
+                                        `name`="group", 
+                                        `type`="text", 
+                                        `title`="Group"),
+                                    list(
+                                        `name`="lhs", 
+                                        `type`="text", 
+                                        `title`="Dep"),
+                                    list(
+                                        `name`="rhs", 
+                                        `type`="text", 
+                                        `title`="Pred"),
+                                    list(
+                                        `name`="beta", 
+                                        `type`="number", 
+                                        `title`="\u03B2"),
+                                    list(
+                                        `name`="lower", 
+                                        `type`="number", 
+                                        `title`="Lower"),
+                                    list(
+                                        `name`="upper", 
+                                        `type`="number", 
+                                        `title`="Upper")))))}))$new(options=options))
             self$add(jmvcore::Table$new(
                 options=options,
                 name="contraintsnotes",
@@ -1344,3 +1362,4 @@ pathjBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 requiresMissings = FALSE,
                 weightsSupport = 'auto')
         }))
+

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -1285,7 +1285,7 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     "pcurve_linetype",
                                     "pcurve_lwd",
                                     "pcurve_palette",
-                                    "pcurve_ribbons")))))}))$new(options=options))
+                                    "pcurve_ribbons"))))}))$new(options=options))
             self$add(jmvcore::Table$new(
                 options=options,
                 name="contraintsnotes",

--- a/R/pathj.h.R
+++ b/R/pathj.h.R
@@ -1276,7 +1276,34 @@ pathjResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                     "pcurve_sizes",
                                     "pcurve_linetype",
                                     "pcurve_lwd",
-                                    "pcurve_palette"))))}))$new(options=options))
+                                     "pcurve_palette"))))
+                        self$add(jmvcore::Array$new(
+                            options=options,
+                            name="betaci",
+                            title="Standardized Effects (β) – 95% CI",
+                            visible="(pgraphs)",
+                            template=jmvcore::Table$new(
+                                options=options,
+                                title="$key",
+                                renderFun=".tableBetaCI",
+                                clearWith=list(
+                                    "endogenous",
+                                    "covs",
+                                    "factors",
+                                    "multigroup",
+                                    "constraints",
+                                    "endogenousTerms",
+                                    "data",
+                                    "varcov",
+                                    "cov_y",
+                                    "pgraphs"),
+                                columns=list(
+                                    list(`name`="group", `type`="text", `title`="Group"),
+                                    list(`name`="lhs", `type`="text", `title`="Dep"),
+                                    list(`name`="rhs", `type`="text", `title`="Pred"),
+                                    list(`name`="beta", `type`="number", `title`="β"),
+                                    list(`name`="lower", `type`="number", `title`="Lower"),
+                                    list(`name`="upper", `type`="number", `title`="Upper"))))))}))$new(options=options))
             self$add(jmvcore::Table$new(
                 options=options,
                 name="contraintsnotes",
@@ -1317,4 +1344,3 @@ pathjBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 requiresMissings = FALSE,
                 weightsSupport = 'auto')
         }))
-

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -1,7 +1,7 @@
 ---
 title: Path Analysis
 name: pathj
-version: 1.1.3
+version: 1.1.4
 jms: '1.0'
 authors:
   - Marcello Gallucci

--- a/jamovi/pathj.a.yaml
+++ b/jamovi/pathj.a.yaml
@@ -299,6 +299,54 @@ options:
           R: >
             `TRUE` or `FALSE` (default), produce a path diagram
 
+    # P-value graphs across sample sizes
+    - name: pgraphs
+      title: Show p-value graphs
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default). When TRUE, fits the model on
+            varying sample sizes and draws p-value vs sample-size lines for
+            each predictor.
+
+    - name: pcurve_sizes
+      title: Sample sizes
+      type: String
+      default: '50, 100, 200, 500'
+      description:
+          R: >
+            Comma-separated sample sizes to project to (e.g., '50,100,200,500').
+
+    - name: pcurve_linetype
+      title: Line type
+      type: List
+      options:
+        - name: solid
+          title: Solid
+        - name: dashed
+          title: Dashed
+        - name: dotted
+          title: Dotted
+      default: solid
+
+    - name: pcurve_lwd
+      title: Line width
+      type: Number
+      default: 1.2
+      min: 0.2
+      max: 5
+
+    - name: pcurve_palette
+      title: Palette
+      type: List
+      options:
+        - name: default
+          title: Default
+        - name: okabeito
+          title: Colorblind (Okabe-Ito)
+      default: default
+
     - name: diag_paths
       title: Paths Labels
       type: List

--- a/jamovi/pathj.a.yaml
+++ b/jamovi/pathj.a.yaml
@@ -347,6 +347,11 @@ options:
           title: Colorblind (Okabe-Ito)
       default: default
 
+    - name: pcurve_ribbons
+      title: Show 95% CI ribbons
+      type: Bool
+      default: true
+
     - name: diag_paths
       title: Paths Labels
       type: List

--- a/jamovi/pathj.a.yaml
+++ b/jamovi/pathj.a.yaml
@@ -347,6 +347,11 @@ options:
           title: Colorblind (Okabe-Ito)
       default: default
 
+    - name: pcurve_ci
+      title: Show 95% CI
+      type: Bool
+      default: false
+
     - name: diag_paths
       title: Paths Labels
       type: List

--- a/jamovi/pathj.a.yaml
+++ b/jamovi/pathj.a.yaml
@@ -347,11 +347,6 @@ options:
           title: Colorblind (Okabe-Ito)
       default: default
 
-    - name: pcurve_ci
-      title: Show 95% CI
-      type: Bool
-      default: false
-
     - name: diag_paths
       title: Paths Labels
       type: List

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -659,43 +659,7 @@ items:
                     - pcurve_palette
                     - pcurve_ribbons
 
-           - name: betaci
-             title: Standardized Effects (β) – 95% CI
-             type: Array
-             visible: (pgraphs)
-             template:
-                title: $key
-                type: Table
-                clearWith:
-                   - endogenous
-                   - covs
-                   - factors
-                   - multigroup
-                   - constraints
-                   - endogenousTerms
-                   - data
-                   - varcov
-                   - cov_y
-                   - pgraphs
-                columns:
-                   - name: group
-                     type: text
-                     title: Group
-                   - name: lhs
-                     type: text
-                     title: Dep
-                   - name: rhs
-                     type: text
-                     title: Pred
-                   - name: beta
-                     type: number
-                     title: β
-                   - name: lower
-                     type: number
-                     title: Lower
-                   - name: upper
-                     type: number
-                     title: Upper
+            
                    
 
   - name: contraintsnotes

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -657,6 +657,7 @@ items:
                    - pcurve_linetype
                    - pcurve_lwd
                    - pcurve_palette
+                   - pcurve_ci
 
   - name: contraintsnotes
     type: Table

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -656,7 +656,8 @@ items:
                    - pcurve_sizes
                    - pcurve_linetype
                    - pcurve_lwd
-                   - pcurve_palette
+                    - pcurve_palette
+                    - pcurve_ribbons
 
            - name: betaci
              title: Standardized Effects (β) – 95% CI

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -657,6 +657,45 @@ items:
                    - pcurve_linetype
                    - pcurve_lwd
                    - pcurve_palette
+
+           - name: betaci
+             title: Standardized Effects (β) – 95% CI
+             type: Array
+             visible: (pgraphs)
+             template:
+                title: $key
+                type: Table
+                renderFun: .tableBetaCI
+                clearWith:
+                   - endogenous
+                   - covs
+                   - factors
+                   - multigroup
+                   - constraints
+                   - endogenousTerms
+                   - data
+                   - varcov
+                   - cov_y
+                   - pgraphs
+                columns:
+                   - name: group
+                     type: text
+                     title: Group
+                   - name: lhs
+                     type: text
+                     title: Dep
+                   - name: rhs
+                     type: text
+                     title: Pred
+                   - name: beta
+                     type: number
+                     title: β
+                   - name: lower
+                     type: number
+                     title: Lower
+                   - name: upper
+                     type: number
+                     title: Upper
                    
 
   - name: contraintsnotes

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -615,9 +615,48 @@ items:
              title: ""
              visible: false
              columns:
-                  - name: message
-                    type: text
-                    title: "Model diagram notes"
+                   - name: message
+                     type: text
+                     title: "Model diagram notes"
+
+  # P-value graphs
+  - name: pgraphs
+    type: Group
+    title: P-Value Graphs
+    visible: (pgraphs)
+    clearWith:
+                  - endogenous
+                  - cov_y
+                  - constraints
+                  - varcov
+                  - data
+                  - multigroup
+    items:
+           - name: pcurves
+             title: P-Value Curves
+             type: Array
+             visible: (pgraphs)
+             template:
+                title: $key
+                type: Image
+                renderFun: .plotPvalues
+                width: 900
+                height: 500
+                clearWith:
+                   - endogenous
+                   - covs
+                   - factors
+                   - multigroup
+                   - constraints
+                   - endogenousTerms
+                   - data
+                   - varcov
+                   - cov_y
+                   - pgraphs
+                   - pcurve_sizes
+                   - pcurve_linetype
+                   - pcurve_lwd
+                   - pcurve_palette
 
   - name: contraintsnotes
     type: Table

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -665,7 +665,6 @@ items:
              template:
                 title: $key
                 type: Table
-                renderFun: .tableBetaCI
                 clearWith:
                    - endogenous
                    - covs

--- a/jamovi/pathj.r.yaml
+++ b/jamovi/pathj.r.yaml
@@ -657,7 +657,7 @@ items:
                    - pcurve_linetype
                    - pcurve_lwd
                    - pcurve_palette
-                   - pcurve_ci
+                   
 
   - name: contraintsnotes
     type: Table

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -509,3 +509,36 @@ children:
             stretchFactor: 0.5
             template:
               type: ComboBox
+
+  - type: CollapseBox
+    label: P-Value Graphs
+    collapsed: true
+    stretchFactor: 1
+    style: list
+    children:
+      - type: LayoutBox
+        margin: large
+        stretchFactor: 1
+        children:
+          - type: CheckBox
+            name: pgraphs
+            label: Show p-value graphs
+          - type: TextBox
+            name: pcurve_sizes
+            label: Sample sizes
+            format: text
+            enable: (pgraphs)
+            stretchFactor: 1
+          - type: ComboBox
+            name: pcurve_palette
+            label: Palette
+            enable: (pgraphs)
+          - type: ComboBox
+            name: pcurve_linetype
+            label: Line type
+            enable: (pgraphs)
+          - type: TextBox
+            name: pcurve_lwd
+            label: Line width
+            format: number
+            enable: (pgraphs)

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -535,8 +535,4 @@ children:
             label: Line width
             format: number
             enable: (pgraphs)
-          - type: CheckBox
-            name: pcurve_ci
-            label: Show 95% CI
-            enable: (pgraphs)
   

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -535,4 +535,8 @@ children:
             label: Line width
             format: number
             enable: (pgraphs)
+          - type: CheckBox
+            name: pcurve_ci
+            label: Show 95% CI
+            enable: (pgraphs)
   

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -535,4 +535,8 @@ children:
             label: Line width
             format: number
             enable: (pgraphs)
+          - type: CheckBox
+            name: pcurve_ribbons
+            label: Show 95% CI ribbons
+            enable: (pgraphs)
   

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -521,8 +521,7 @@ children:
             name: pcurve_sizes
             label: Sample sizes
             format: text
-            enable: (pgraphs)
-            stretchFactor: 1
+            visible: (pgraphs)
           - type: ComboBox
             name: pcurve_palette
             label: Palette

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -520,8 +520,8 @@ children:
           - type: TextBox
             name: pcurve_sizes
             label: Sample sizes
-            format: text
-            visible: (pgraphs)
+            format: string
+            enable: (pgraphs)
           - type: ComboBox
             name: pcurve_palette
             label: Palette

--- a/jamovi/pathj.u.yaml
+++ b/jamovi/pathj.u.yaml
@@ -3,7 +3,7 @@ name: pathj
 jus: '2.0'
 compilerMode: tame
 events:
-  update: './pathj.events::update'
+  update: ./pathj.events::update
 children:
   - type: VariableSupplier
     name: variablesupplier
@@ -20,21 +20,21 @@ children:
             name: endogenous
             isTarget: true
             events:
-              change: './pathj.events::onChange_endogenous'
+              change: ./pathj.events::onChange_endogenous
       - type: TargetLayoutBox
         children:
           - type: VariablesListBox
             name: factors
             isTarget: true
             events:
-              change: './pathj.events::onChange_factors'
+              change: ./pathj.events::onChange_factors
       - type: TargetLayoutBox
         children:
           - type: VariablesListBox
             name: covs
             isTarget: true
             events:
-              change: './pathj.events::onChange_covariates'
+              change: ./pathj.events::onChange_covariates
       - type: TargetLayoutBox
         children:
           - type: VariablesListBox
@@ -57,8 +57,8 @@ children:
             persistentItems: true
             stretchFactor: 1
             events:
-              update: './pathj.events::onChange_endogenousSupplier'
-              change: './pathj.events::onChange_endogenousSupplier'
+              update: ./pathj.events::onChange_endogenousSupplier
+              change: ./pathj.events::onChange_endogenousSupplier
             children:
               - type: TargetLayoutBox
                 transferAction: interactions
@@ -86,7 +86,7 @@ children:
                           height: auto
                           ghostText: drag variables here
                           events:
-                            change: './pathj.events::onChange_endogenousTerms'
+                            change: ./pathj.events::onChange_endogenousTerms
                           template:
                             type: TermLabel
   - type: CollapseBox
@@ -105,8 +105,8 @@ children:
             persistentItems: true
             stretchFactor: 1
             events:
-              change: './pathj.events::onChange_varcovSupplier'
-              update: './pathj.events::onUpdate_varcovSupplier'
+              change: ./pathj.events::onChange_varcovSupplier
+              update: ./pathj.events::onUpdate_varcovSupplier
             children:
               - type: TargetLayoutBox
                 label: Select pairs
@@ -153,7 +153,7 @@ children:
                 name: estimator
               - type: ComboBox
                 name: likelihood
-                enable: '(estimator:ML)'
+                enable: (estimator:ML)
           - type: Label
             label: Inferential Tests
             margin: large
@@ -173,9 +173,6 @@ children:
                 type: CheckBox
                 optionPart: Satterthwaite
                 optionName: tests
-                
-
-
   - type: CollapseBox
     label: Parameters Options
     collapsed: true
@@ -230,26 +227,26 @@ children:
                 name: bootci_bootperc
                 optionName: bootci
                 optionPart: perc
-                enable: '(se:boot)'
+                enable: (se:boot)
               - type: RadioButton
                 name: bootci_bootnorm
                 optionName: bootci
                 optionPart: norm
-                enable: '(se:boot)'
+                enable: (se:boot)
               - name: bootci_bca.simple
                 type: RadioButton
                 optionName: bootci
                 optionPart: bca.simple
-                enable: '(se:boot)'
+                enable: (se:boot)
               - type: RadioButton
                 name: bootci_basic
                 optionName: bootci
                 optionPart: basic
-                enable: '(se:boot)'
+                enable: (se:boot)
               - type: TextBox
                 name: bootN
                 format: number
-                enable: '(se:boot)'
+                enable: (se:boot)
       - type: LayoutBox
         margin: large
         style: inline
@@ -272,7 +269,6 @@ children:
             children:
               - type: CheckBox
                 name: cov_x
-
   - type: CollapseBox
     label: Model Diagnostics
     collapsed: true
@@ -343,7 +339,6 @@ children:
               - type: CheckBox
                 name: diag_offset_labs
                 enable: (diagram)
-                
       - type: LayoutBox
         margin: large
         stretchFactor: 1
@@ -509,7 +504,6 @@ children:
             stretchFactor: 0.5
             template:
               type: ComboBox
-
   - type: CollapseBox
     label: P-Value Graphs
     collapsed: true
@@ -542,3 +536,4 @@ children:
             label: Line width
             format: number
             enable: (pgraphs)
+  


### PR DESCRIPTION
Highlights:

P‑value curves: projected from z via z*sqrt(n/Nobs).
Multi‑group panels: one image per group level.
Controls: sample sizes, line type (solid/dashed/dotted), line width, palette (Default, Okabe–Ito).
Reference line: dashed horizontal p = 0.05.
Caption: lists the sample sizes used.
Toggle: “Show 95% CI ribbons” (ribbons match line colors).
UI/UX:

“Sample sizes” moved inside the P‑Value Graphs section; only visible when that section is expanded and “Show p‑value graphs” is on.
New checkbox “Show 95% CI ribbons”.